### PR TITLE
Removed uncessary channel crushing

### DIFF
--- a/pywhispercpp/model.py
+++ b/pywhispercpp/model.py
@@ -272,9 +272,7 @@ class Model:
         """
         sound = AudioSegment.from_file(media_file_path)
         sound = sound.set_frame_rate(constants.WHISPER_SAMPLE_RATE).set_channels(1)
-        channel_sounds = sound.split_to_mono()
-        samples = [s.get_array_of_samples() for s in channel_sounds]
-        arr = np.array(samples).T.astype(np.float32)
+        arr = np.array(sound.get_array_of_samples()).T.astype(np.float32)
         arr /= np.iinfo(samples[0].typecode).max
         return arr
 


### PR DESCRIPTION
Calling ```set_channels(1) already converts the audio to one channel, so there was no need to call ```split_to_mono```, instead we can just call ```get_array_of_samples```

This should have a negligible positive impact on performance. Can someone test this quickly for me? I'm not in a position to test at the moment. 