### PR TITLE
re-add "unnecessary" normalization to fix UTF-8 errors.

### DIFF
--- a/pywhispercpp/model.py
+++ b/pywhispercpp/model.py
@@ -273,6 +273,7 @@ class Model:
         sound = AudioSegment.from_file(media_file_path)
         sound = sound.set_frame_rate(constants.WHISPER_SAMPLE_RATE).set_channels(1)
         arr = np.array(sound.get_array_of_samples()).T.astype(np.float32)
+        arr /= np.iinfo(np.int16).max
         return arr
 
     def __del__(self):

--- a/pywhispercpp/model.py
+++ b/pywhispercpp/model.py
@@ -273,7 +273,6 @@ class Model:
         sound = AudioSegment.from_file(media_file_path)
         sound = sound.set_frame_rate(constants.WHISPER_SAMPLE_RATE).set_channels(1)
         arr = np.array(sound.get_array_of_samples()).T.astype(np.float32)
-        arr /= np.iinfo(samples[0].typecode).max
         return arr
 
     def __del__(self):


### PR DESCRIPTION
I forgot to remove this line yesterday, I'm not sure why it's not causing any issues having it there referencing a nonexistent variable ```samples``` but it seems like normalization wasn't required based on transcription testing I've done so far.