### PR TITLE
Provide new_segment_callback with Segment, not list[Segment], fixing type hints

### DIFF
--- a/pywhispercpp/model.py
+++ b/pywhispercpp/model.py
@@ -261,7 +261,7 @@ class Model:
         n = pw.whisper_full_n_segments(ctx)
         start = n - n_new
         res = Model._get_segments(ctx, start, n)
-        Model._new_segment_callback(res[0])
+        [Model._new_segment_callback(segment) for segment in res]
 
     @staticmethod
     def _load_audio(media_file_path: str) -> np.array:

--- a/pywhispercpp/model.py
+++ b/pywhispercpp/model.py
@@ -261,7 +261,7 @@ class Model:
         n = pw.whisper_full_n_segments(ctx)
         start = n - n_new
         res = Model._get_segments(ctx, start, n)
-        Model._new_segment_callback(res)
+        Model._new_segment_callback(res[0])
 
     @staticmethod
     def _load_audio(media_file_path: str) -> np.array:

--- a/pywhispercpp/model.py
+++ b/pywhispercpp/model.py
@@ -261,7 +261,8 @@ class Model:
         n = pw.whisper_full_n_segments(ctx)
         start = n - n_new
         res = Model._get_segments(ctx, start, n)
-        [Model._new_segment_callback(segment) for segment in res]
+        for segment in res:
+            Model._new_segment_callback(segment)
 
     @staticmethod
     def _load_audio(media_file_path: str) -> np.array:


### PR DESCRIPTION
In my editor, it's shown that ` new_segment_callback` is to be provided a `Segment`,  but it actually provides a list[Segment] with one element. I've changed this by just returning that first element so that it matches the type hints.