### PR TITLE
fixes #68

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -480,10 +480,17 @@ PYBIND11_MODULE(_pywhispercpp, m) {
         .def_readwrite("initial_prompt", &whisper_full_params::initial_prompt)
         .def_readwrite("prompt_tokens", &whisper_full_params::prompt_tokens)
         .def_readwrite("prompt_n_tokens", &whisper_full_params::prompt_n_tokens)
-        .def_property("language", [](whisper_full_params &self) {return py::str(self.language);},
-                                 [](whisper_full_params &self, const char *new_c) {char* c = (char *)malloc(sizeof(new_c));
-                                                                                    strcpy(c, new_c); self.language = c;})
-
+        .def_property("language", 
+            [](whisper_full_params &self) { 
+                return py::str(self.language); 
+            },
+            [](whisper_full_params &self, const char *new_c) {
+                if (new_c == nullptr) {
+                    new_c = "";
+                }
+                free((void *)self.language);
+                self.language = strdup(new_c);
+            })
         .def_readwrite("suppress_blank", &whisper_full_params::suppress_blank)
         .def_readwrite("suppress_non_speech_tokens", &whisper_full_params::suppress_non_speech_tokens)
         .def_readwrite("temperature", &whisper_full_params::temperature)

--- a/tests/test_c_api.py
+++ b/tests/test_c_api.py
@@ -18,6 +18,19 @@ class TestCAPI(TestCase):
     def test_whisper_lang_id(self):
         return self.assertEqual(pw.whisper_lang_id('en'), 0)
 
+    def test_whisper_full_params_language_set_to_de(self):
+        params = pw.whisper_full_params()
+        params.language = 'de'
+        return self.assertEqual(params.language, 'de')
+    
+    def test_whisper_full_params_language_set_to_german(self):
+        """breaks malloc free /error"""
+        params = pw.whisper_full_params()
+        params.language = 'german'
+        return self.assertEqual(params.language, 'german')
+
+    def test_whisper_lang_id(self):
+        return self.assertEqual(pw.whisper_lang_id('en'), 0)
     def test_whisper_full_params(self):
         params = pw.whisper_full_params()
         return self.assertIsInstance(params.n_threads, int)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -5,6 +5,7 @@
 Test model.py
 """
 import unittest
+from pathlib import Path
 from unittest import TestCase
 
 from pywhispercpp.model import Model, Segment
@@ -12,13 +13,14 @@ from pywhispercpp.model import Model, Segment
 if __name__ == '__main__':
     pass
 
+WHISPER_CPP_DIR = Path(__file__).parent.parent / 'whisper.cpp'
 
 class TestModel(TestCase):
-    audio_file = '../whisper.cpp/samples/jfk.wav'
-    model = Model("tiny")
+    audio_file = WHISPER_CPP_DIR/ 'samples/jfk.wav'
+    model = Model("tiny", models_dir=str(WHISPER_CPP_DIR/'models'))
 
     def test_transcribe(self):
-        segments = self.model.transcribe(self.audio_file)
+        segments = self.model.transcribe(str(self.audio_file))
         return self.assertIsInstance(segments, list) and \
                self.assertIsInstance(segments[0], Segment) if len(segments) > 0 else True
 
@@ -35,7 +37,7 @@ class TestModel(TestCase):
         return self.assertIsInstance(av_langs, list) and self.assertGreater(len(av_langs), 1)
 
     def test__load_audio(self):
-        audio_arr = self.model._load_audio(self.audio_file)
+        audio_arr = self.model._load_audio(str(self.audio_file))
         return self.assertIsNotNone(audio_arr)
 
 


### PR DESCRIPTION
Fixes the issue with params incorrectly handling language memory allocation
I've added some test that fails without the fix.
As well I fixed the tests so that they run on my mac with coreml support.