### PR TITLE
Fix 'unknown language', coreml loading and  bump whisper 

### DIFF
--- a/pywhispercpp/__init__.py
+++ b/pywhispercpp/__init__.py
@@ -4,11 +4,12 @@ from glob import glob
 
 # ggml should be loaded first
 ggml_libs = glob(os.path.join(os.path.dirname(__file__), 'lib/*ggml*'))
+coreml_libs = glob(os.path.join(os.path.dirname(__file__), 'lib/*coreml*'))
 libs = glob(os.path.join(os.path.dirname(__file__), 'lib/*'))
 
 # Append lib dir to PATH
 if os.name == 'nt':
     os.add_dll_directory(os.path.join(os.path.dirname(__file__), 'lib'))
 
-for file in ggml_libs + libs:
+for file in ggml_libs + coreml_libs + libs:
     ctypes.CDLL(os.path.join(os.path.dirname(__file__), 'lib', file))

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -585,7 +585,7 @@ PYBIND11_MODULE(_pywhispercpp, m) {
                 return py::str(self.language); 
             },
             [](WhisperFullParamsWrapper &self, const char *new_c) {// using lang_id let us avoid issues with memory management
-                const int lang_id = whisper_lang_id(new_c);
+                const int lang_id = (new_c && strlen(new_c) > 0) ? whisper_lang_id(new_c) : -1;
                 if (lang_id != -1) {
                     self.language = whisper_lang_str(lang_id);    
                 } else {


### PR DESCRIPTION
These changes are pretty safe. I’ve tested Whisper 1.7.1, and it’s working well with all tests passing; I’m using it right now. The CoreML was functioning, but it broke when I deleted the build directory because it was being pulled from there. I fixed it the same way we handle loading GGML. I think I have a better solution in mind, but since it’s a substantial change, I’ve decided to put it in a separate pull request.