### PR TITLE
Use repairwheel to fix the .dylib linkage. 

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -15,7 +15,7 @@ jobs:
     name: Build SDist
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: true
 
@@ -39,25 +39,30 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: true
+    # Used to host cibuildwheel
+    - uses: actions/setup-python@v5
 
-    - uses: pypa/cibuildwheel@v2.16.5
+    - name: Install cibuildwheel
+      run: python -m pip install cibuildwheel==2.21.3
+
+    - name: Build wheels
+      run: python -m cibuildwheel --output-dir wheelhouse
       env:
         CIBW_ARCHS_MACOS: auto universal2
-        CIBW_REPAIR_WHEEL_COMMAND_MACOS: ""
-        CIBW_REPAIR_WHEEL_COMMAND_LINUX: ""
-        # Repair windows wheel
-#        CIBW_BEFORE_BUILD_WINDOWS: "pip install delvewheel"
-#        CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: "delvewheel repair -w {dest_dir} {wheel}"
+         # for windows setup.py repairwheel step should solve it
 
     - name: Verify clean directory
       run: git diff --exit-code
       shell: bash
 
+    - name: List files
+      run: ls wheelhouse
+      
     - name: Upload wheels
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v3 # v4 does not support overwriting artifacts anymore.
       with:
         path: wheelhouse/*.whl
 
@@ -69,11 +74,11 @@ jobs:
     if: github.event_name == 'release' && github.event.action == 'published'
 
     steps:
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: "3.x"
 
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: artifact
         path: dist

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,8 +35,6 @@ test-skip = ["*universal2:arm64"]
 # Setuptools bug causes collision between pypy and cpython artifacts
 before-build = "rm -rf {project}/build"
 
-#repair-wheel-command = "wheelrepair \"{wheel}\" -O build/ ; mv build/*.whl {wheel}" # TODO: figure out if this works alread after adding it to setup.py
- 
 [tool.ruff]
 extend-select = [
   "B",    # flake8-bugbear

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ requires = [
     "wheel",
     "ninja",
     "cmake>=3.12",
+    "repairwheel",
 ]
 build-backend = "setuptools.build_meta"
 
@@ -34,6 +35,8 @@ test-skip = ["*universal2:arm64"]
 # Setuptools bug causes collision between pypy and cpython artifacts
 before-build = "rm -rf {project}/build"
 
+#repair-wheel-command = "wheelrepair \"{wheel}\" -O build/ ; mv build/*.whl {wheel}" # TODO: figure out if this works alread after adding it to setup.py
+ 
 [tool.ruff]
 extend-select = [
   "B",    # flake8-bugbear

--- a/setup.py
+++ b/setup.py
@@ -145,6 +145,11 @@ long_description = (this_directory / "README.md").read_text()
 class RepairWheel(bdist_wheel):
     def run(self):
         super().run()
+        if os.environ.get('CIBUILDWHEEL', '0') == '0' or sys.platform.startswith('win'):
+            # for linux and macos we use the default wheel repair command from cibuildwheel, for windows we need to do it manually as there is no repair command
+            self.repair_wheel()
+
+    def repair_wheel(self):
         # on windows the dlls are in D:\a\pywhispercpp\pywhispercpp\build\temp.win-amd64-cpython-311\Release\_pywhispercpp\bin\Release\whisper.dll
         global dll_folder
         print("dll_folder in repairwheel",dll_folder) 

--- a/setup.py
+++ b/setup.py
@@ -2,12 +2,12 @@ import os
 import re
 import subprocess
 import sys
-from glob import glob
 from pathlib import Path
+import subprocess
 
 from setuptools import Extension, setup, find_packages
 from setuptools.command.build_ext import build_ext
-
+from setuptools.command.bdist_wheel import bdist_wheel
 # Convert distutils Windows platform specifiers to CMake -A arguments
 PLAT_TO_CMAKE = {
     "win32": "Win32",
@@ -25,6 +25,7 @@ class CMakeExtension(Extension):
         super().__init__(name, sources=[])
         self.sourcedir = os.fspath(Path(sourcedir).resolve())
 
+dll_folder = 'unset'
 
 class CMakeBuild(build_ext):
     def build_extension(self, ext: CMakeExtension) -> None:
@@ -130,25 +131,40 @@ class CMakeBuild(build_ext):
 
     def copy_extensions_to_source(self):
         super().copy_extensions_to_source()
-        # Copy the shared library to the lib folder
-        ext_fullpath = Path.cwd() / self.get_ext_fullpath(self.extensions[0].name)  # type: ignore[no-untyped-call]
-        extdir = ext_fullpath.parent.resolve()
-        so_files = os.path.join(extdir, '*.so*')
-        dylib_files = os.path.join(extdir, '*.dylib')
+        # store the dll folder in a global variable to use in repairwheel
+        global dll_folder
         cfg = "Debug" if self.debug else "Release"
-        dll_files = os.path.join(self.build_temp, '_pywhispercpp', 'bin', cfg, "*.dll")
-        shared_libs =  glob(so_files) + glob(dll_files) + glob(dylib_files)
-        shared_libs = [f for f in shared_libs if not Path(f).name.startswith("_")] # exclude the extension itself
-        dest_folder = Path.cwd() / 'pywhispercpp' / 'lib'
-        if not dest_folder.resolve().exists():
-            dest_folder.mkdir(parents=True)
-        for file_path in shared_libs:
-            filename = os.path.basename(file_path)
-            self.copy_file(file_path, (dest_folder / filename).resolve())
+        dll_folder = os.path.join(self.build_temp, '_pywhispercpp', 'bin', cfg)
+
 
 # read the contents of your README file
 this_directory = Path(__file__).parent
 long_description = (this_directory / "README.md").read_text()
+
+
+class RepairWheel(bdist_wheel):
+    def run(self):
+        super().run()
+        # on windows the dlls are in D:\a\pywhispercpp\pywhispercpp\build\temp.win-amd64-cpython-311\Release\_pywhispercpp\bin\Release\whisper.dll
+        global dll_folder
+        print("dll_folder in repairwheel",dll_folder) 
+        print("Files in dll_folder:", *Path(dll_folder).glob('*'))
+        #build\temp.win-amd64-cpython-311\Release\_pywhispercpp\bin\Release\whisper.dll
+       
+        wheel_path = next(Path(self.dist_dir).glob(f"{self.distribution.get_name()}*.whl"))
+        # Create a temporary directory for the repaired wheel
+        import tempfile
+        with tempfile.TemporaryDirectory(prefix='repaired_wheel_') as tmp_dir:
+            tmp_dir = Path(tmp_dir)
+            subprocess.call(['repairwheel', wheel_path, '-o', tmp_dir, '-l', dll_folder])
+            print("Repaired wheel: ", *tmp_dir.glob('*.whl'))
+            # We need to glob as repairwheel may change the name of the wheel 
+            # on linux from pywhispercpp-1.2.0-cp312-cp312-linux_aarch64.whl 
+            #            to pywhispercpp-1.2.0-cp312-cp312-manylinux_2_34_aarch64.whl
+            repaired_wheel = next(tmp_dir.glob("*.whl"))
+            self.copy_file(repaired_wheel, wheel_path)
+            print(f"Copied repaired wheel to: {wheel_path}")
+     
 
 # The information here can also be placed in setup.cfg - better separation of
 # logic and declaration, and simpler if you include description/version in a file.
@@ -159,14 +175,15 @@ setup(
     description="Python bindings for whisper.cpp",
     long_description=long_description,
     ext_modules=[CMakeExtension("_pywhispercpp")],
-    cmdclass={"build_ext": CMakeBuild},
+    cmdclass={"build_ext": CMakeBuild,
+             'bdist_wheel': RepairWheel,},
     zip_safe=False,
     # extras_require={"test": ["pytest>=6.0"]},
     python_requires=">=3.8",
     packages=find_packages('.'),
     package_dir={'': '.'},
     include_package_data=True,
-    package_data={'pywhispercpp': ['lib/*']},
+    package_data={'pywhispercpp': []},
     long_description_content_type="text/markdown",
     license='MIT',
     entry_points={
@@ -182,4 +199,5 @@ setup(
     },
     install_requires=['numpy', "requests", "tqdm", "platformdirs"],
     extras_require={"examples": ["sounddevice", "webrtcvad"]},
+
 )


### PR DESCRIPTION
I'm still unsure if this is the best approach but I wanted `pip install .` to  work, normally there is an option in cibuildwheel that let us run repairwheel, but this leaves the pip install broken.

It is quite difficult to find information how to do it properly, so I'm still unsure that it is right solution as we are still ending up with libs in two places in the wheel, but at least they reference them selfs correctly so which ever is picked first the rest is loaded.

I've tested this only on my mac so I'm not sure that it is working correctly in windows and linux but it should as repairwheel is multiplatform.

After repair the libs are in pywhispercpp-1.2.0/*.dylib and in pywhispercpp-1.2.0/pywhispercpp/.dylibs/*.dylib, but they reference each other have a look at the output of otool -L
```
otool -L pywhispercpp-1.2.0/libwhisper.1.7.1.dylib
pywhispercpp-1.2.0/libwhisper.1.7.1.dylib:
        @rpath/libwhisper.1.dylib (compatibility version 1.0.0, current version 1.7.1)
        @loader_path/pywhispercpp/.dylibs/libggml.dylib (compatibility version 0.0.0, current version 0.0.0)
        @loader_path/pywhispercpp/.dylibs/libwhisper.coreml.dylib (compatibility version 0.0.0, current version 0.0.0)
        /usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 1800.101.0)
        /usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1351.0.0)
```

````
otool -L pywhispercpp-1.2.0/pywhispercpp/.dylibs/libwhisper.1.7.1.dylib
pywhispercpp-1.2.0/pywhispercpp/.dylibs/libwhisper.1.7.1.dylib:
        /DLC/pywhispercpp/.dylibs/libwhisper.1.7.1.dylib (compatibility version 1.0.0, current version 1.7.1)
        @loader_path/libggml.dylib (compatibility version 0.0.0, current version 0.0.0)
        @loader_path/libwhisper.coreml.dylib (compatibility version 0.0.0, current version 0.0.0)
        /usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 1800.101.0)
        /usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1351.0.0)
```


-----
This pr is based on #74, as I'm assuming it won't be merged before it, as it needs test.  Only the last commit matters.
I've tested this on macos, I'm not sure if it will work on other platforms though. Could you check on yours?