### PR TITLE
Fix repairwheel on linux

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,20 +67,20 @@ class CMakeBuild(build_ext):
             f"-DPYTHON_EXECUTABLE={sys.executable}",
             f"-DCMAKE_BUILD_TYPE={cfg}",  # not used on MSVC, but no harm
         ]
-        
-        # Platform-specific rpath settings
-        if sys.platform.startswith('darwin'):
-            # macOS-specific settings
-            cmake_args += [
-                "-DCMAKE_INSTALL_RPATH=@loader_path",
-                "-DCMAKE_BUILD_WITH_INSTALL_RPATH=ON"
-            ]
-        elif sys.platform.startswith('linux'):
-            # Linux-specific settings
-            cmake_args += [
-                "-DCMAKE_INSTALL_RPATH=$ORIGIN",
-                "-DCMAKE_BUILD_WITH_INSTALL_RPATH=ON"
-            ]
+        if self.editable_mode:
+            # Platform-specific rpath settings
+            if sys.platform.startswith('darwin'):
+                # macOS-specific settings
+                cmake_args += [
+                    "-DCMAKE_INSTALL_RPATH=@loader_path",
+                    "-DCMAKE_BUILD_WITH_INSTALL_RPATH=ON"
+                ]
+            elif sys.platform.startswith('linux'):
+                # Linux-specific settings
+                cmake_args += [
+                    "-DCMAKE_INSTALL_RPATH=$ORIGIN",
+                    "-DCMAKE_BUILD_WITH_INSTALL_RPATH=ON"
+                ]
 
         build_args = []
         # Adding CMake arguments set as environment variable
@@ -168,7 +168,7 @@ class CMakeBuild(build_ext):
     def copy_extensions_to_source(self):
         super().copy_extensions_to_source()
        
-        if self.inplace:
+        if self.editable_mode:
             build_lib = Path(self.build_lib)
             for ext in self.extensions:
                 extdir = Path(self.get_ext_fullpath(ext.name)).parent.resolve()


### PR DESCRIPTION
The package was failing on unbuntu because of the change I've made to support  editable mode, so I've made the change conditional and run  only when pip install -e . is executed.
 
This showed another issue though. On linux our wheels contains the libwhipser.so twice, and one is redundant, we should fix that, I will create a new pull request once I figure out how.

To give you more info setting rpath to  $ORIGIN, breaks the wheels after repair step because the dependencies aren't copied to pywhispercpp.libs and rpath is corrected to $ORIGN/pywhipsercpp.libs.

This is how the readelf of _pywhispercpp.cpython-312-aarch64-linux-gnu.so looks like on linux for a working wheel:
```
  0x000000000000000f (RPATH)              Library rpath: [$ORIGIN/pywhispercpp.libs]
 0x0000000000000001 (NEEDED)             Shared library: [libwhisper-40042964.so.1.7.1]
 0x0000000000000001 (NEEDED)             Shared library: [libstdc++-3f0d3c8a.so.6.0.33]
 0x0000000000000001 (NEEDED)             Shared library: [libgcc_s-1a8c3655.so.1]
 0x0000000000000001 (NEEDED)             Shared library: [libc-07406008.so.6]
 0x0000000000000001 (NEEDED)             Shared library: [ld-linux-aarch64.so.1]
```
 On a broken wheel the libwhisper is not copied to pywhispercpp.libs, and stays as [libwhisper.so.1] here is the output:
 ```
  0x000000000000000f (RPATH)              Library rpath: [$ORIGIN/pywhispercpp.libs]
 0x0000000000000001 (NEEDED)             Shared library: [libwhisper.so.1]
 0x0000000000000001 (NEEDED)             Shared library: [libstdc++-3f0d3c8a.so.6.0.33]
 0x0000000000000001 (NEEDED)             Shared library: [libgcc_s-1a8c3655.so.1]
 0x0000000000000001 (NEEDED)             Shared library: [libc-07406008.so.6]
 0x0000000000000001 (NEEDED)             Shared library: [ld-linux-aarch64.so.1]
 ```

This was build on ubuntu and the libc* where for some reason included in the wheel, I hope it won't happen when build on manylinux image.