### PR TITLE
Better unicode handling for whisper_full_get_segment_text

### DIFF
--- a/pywhispercpp/model.py
+++ b/pywhispercpp/model.py
@@ -151,7 +151,8 @@ class Model:
         for i in range(start, end):
             t0 = pw.whisper_full_get_segment_t0(ctx, i)
             t1 = pw.whisper_full_get_segment_t1(ctx, i)
-            text = pw.whisper_full_get_segment_text(ctx, i)
+            bytes = pw.whisper_full_get_segment_text(ctx, i)
+            text = bytes.decode('utf-8',errors='replace')
             res.append(Segment(t0, t1, text.strip()))
         return res
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -249,8 +249,11 @@ int64_t whisper_full_get_segment_t1_wrapper(struct whisper_context_wrapper * ctx
     return whisper_full_get_segment_t1(ctx->ptr, i_segment);
 }
 
-const char * whisper_full_get_segment_text_wrapper(struct whisper_context_wrapper * ctx, int i_segment){
-     return whisper_full_get_segment_text(ctx->ptr, i_segment);
+// https://pybind11.readthedocs.io/en/stable/advanced/cast/strings.html
+const py::bytes whisper_full_get_segment_text_wrapper(struct whisper_context_wrapper * ctx, int i_segment){
+    const char * c_array = whisper_full_get_segment_text(ctx->ptr, i_segment);
+    size_t length = strlen(c_array); // Determine the length of the array
+    return py::bytes(c_array, length); // Return the data without transcoding
 };
 
 int whisper_full_n_tokens_wrapper(struct whisper_context_wrapper * ctx, int i_segment){


### PR DESCRIPTION
Passing the raw byte array back and use python to decode utf-8 instead to replace invalid unicode characters. Solves https://github.com/absadiki/pywhispercpp/issues/92