### PR TITLE
Fix "_init_model" resseting params of Command Prompt

### DIFF
--- a/pywhispercpp/model.py
+++ b/pywhispercpp/model.py
@@ -228,8 +228,6 @@ class Model:
         logger.info("Initializing the model ...")
         with utils.redirect_stderr(to=self.redirect_whispercpp_logs_to):
             self._ctx = pw.whisper_init_from_file(self.model_path)
-            # Don't set the params to the default ones here, as it will overwrite the user's params
-            # self._params = pw.whisper_full_default_params(pw.whisper_sampling_strategy.WHISPER_SAMPLING_GREEDY)
 
     def _set_params(self, kwargs: dict) -> None:
         """

--- a/pywhispercpp/model.py
+++ b/pywhispercpp/model.py
@@ -228,7 +228,8 @@ class Model:
         logger.info("Initializing the model ...")
         with utils.redirect_stderr(to=self.redirect_whispercpp_logs_to):
             self._ctx = pw.whisper_init_from_file(self.model_path)
-            self._params = pw.whisper_full_default_params(pw.whisper_sampling_strategy.WHISPER_SAMPLING_GREEDY)
+            # Don't set the params to the default ones here, as it will overwrite the user's params
+            # self._params = pw.whisper_full_default_params(pw.whisper_sampling_strategy.WHISPER_SAMPLING_GREEDY)
 
     def _set_params(self, kwargs: dict) -> None:
         """
@@ -242,11 +243,12 @@ class Model:
     def _transcribe(self, audio: np.ndarray, n_processors: int = None):
         """
         Private method to call the whisper.cpp/whisper_full function
-
+    
         :param audio: numpy array of audio data
         :param n_processors: if not None, it will run whisper.cpp/whisper_full_parallel with n_processors
         :return:
         """
+
         if n_processors:
             pw.whisper_full_parallel(self._ctx, self._params, audio, audio.size, n_processors)
         else:

--- a/pywhispercpp/model.py
+++ b/pywhispercpp/model.py
@@ -166,7 +166,11 @@ class Model:
         for param in dir(self._params):
             if param.startswith('__'):
                 continue
-            res[param] = getattr(self._params, param)
+            try:
+                res[param] = getattr(self._params, param)
+            except Exception:
+                # ignore callback functions
+                continue
         return res
 
     @staticmethod


### PR DESCRIPTION
#97 Not the main problem, but one caused by it. Fixed a problem, in these new commit (`version 1.3.1.dev13`), that occurred when calling `pwcpp` from the command line, where there was a line in the code (`_init_model`) which resets what was entered to certain default values ​​(for example, I want to transcribe in Spanish, but it returns it to English with "[Spanish]" and "(speaking in foreign language)"). For this, different lines were added to the code to capture the logs provided by the program in the console (it captured the parameters, but restarted them). Finally, the problem was solved by deleting a line (actually commented), and I deleted the log captures that I placed to identify the problem. I tested the program in the command prompt and in a `.py` file with different parameters, and there were no errors.