### PR TITLE
`Segment` is not subscriptable, removed subscript.

### DIFF
--- a/pywhispercpp/examples/assistant.py
+++ b/pywhispercpp/examples/assistant.py
@@ -120,7 +120,7 @@ class Assistant:
 
     def _new_segment_callback(self, seg):
         if self.commands_callback:
-            self.commands_callback(seg[0].text)
+            self.commands_callback(seg.text)
 
     def start(self) -> None:
         """


### PR DESCRIPTION
Changes:
- As noted in #100, the `Segment` object is not subscriptable, so removed the subscript that is used in `assistant.py`