### PR TITLE
Update the upstream URL to 'ggml-org' organization

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,5 +5,5 @@
 
 [submodule "whisper.cpp"]
     path = whisper.cpp
-    url = https://github.com/ggerganov/whisper.cpp.git
+    url = https://github.com/ggml-org/whisper.cpp.git
     branch = master


### PR DESCRIPTION
This month, the upstream project moved its repository from:

    https://github.com/ggerganov/whisper.cpp.git

to:

    https://github.com/ggml-org/whisper.cpp.git

Update the submodule URL accordingly.

Refer to https://github.com/ggml-org/whisper.cpp/issues/2786 for details about the relocation.