### PR TITLE
Use config-settings instead of env vars for acceleration compilation and wheel repair options

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,43 +56,46 @@ choco install ffmpeg
 scoop install ffmpeg
 ```
 
-### NVIDIA GPU support
-To Install the package with CUDA support, make sure you have [cuda](https://developer.nvidia.com/cuda-downloads) installed and use `GGML_CUDA=1`:
+### Hardware Acceleration
 
+To build with hardware acceleration support, use the `--config-settings` flag:
+
+#### NVIDIA GPU (CUDA)
+Requires [CUDA toolkit](https://developer.nvidia.com/cuda-downloads) installed.
 ```shell
-GGML_CUDA=1 pip install git+https://github.com/absadiki/pywhispercpp
+# With pip
+pip install git+https://github.com/absadiki/pywhispercpp --config-settings="accel=cuda"
+
+# With uv
+uv add git+https://github.com/absadiki/pywhispercpp -Caccel=cuda
+
+# Local install
+pip install . --config-settings="accel=cuda"
 ```
-### CoreML support
 
-Install the package with `WHISPER_COREML=1`:
-
+#### CoreML (Apple Silicon)
 ```shell
-WHISPER_COREML=1 pip install git+https://github.com/absadiki/pywhispercpp
+pip install git+https://github.com/absadiki/pywhispercpp --config-settings="accel=coreml"
 ```
 
-### Vulkan support
-
-Install the package with `GGML_VULKAN=1`:
-
+#### Vulkan
 ```shell
-GGML_VULKAN=1 pip install git+https://github.com/absadiki/pywhispercpp
+pip install git+https://github.com/absadiki/pywhispercpp --config-settings="accel=vulkan"
 ```
 
-### OpenBLAS support
-
-If OpenBLAS is installed, you can use `GGML_BLAS=1`. The other flags ensure you're installing fresh with the correct flags, and printing output for sanity checking.
+#### OpenBLAS
+Requires OpenBLAS to be installed on your system.
 ```shell
-GGML_BLAS=1 pip install git+https://github.com/absadiki/pywhispercpp --no-cache --force-reinstall -v
+pip install git+https://github.com/absadiki/pywhispercpp --config-settings="accel=openblas"
 ```
 
-### OpenVINO support
+#### OpenVINO
+Follow the steps to download correct OpenVINO package from [whisper.cpp OpenVINO docs](https://github.com/ggerganov/whisper.cpp?tab=readme-ov-file#openvino-support).
 
-Follow the the steps to download correct OpenVINO package (https://github.com/ggerganov/whisper.cpp?tab=readme-ov-file#openvino-support).
-
-Then init the OpenVINO environment and build.
-```
+Then initialize the OpenVINO environment and build:
+```shell
 source ~/l_openvino_toolkit_ubuntu22_2023.0.0.10926.b4452d56304_x86_64/setupvars.sh 
-WHISPER_OPENVINO=1 pip install git+https://github.com/absadiki/pywhispercpp --no-cache --force-reinstall
+pip install git+https://github.com/absadiki/pywhispercpp --config-settings="accel=openvino"
 ```
 
 Note that the toolkit for Ubuntu22 works on Ubuntu24

--- a/backend.py
+++ b/backend.py
@@ -1,0 +1,59 @@
+"""Custom PEP 517 build backend that handles config settings for acceleration."""
+
+import os
+from setuptools import build_meta as _orig
+
+# Re-export everything from setuptools
+__all__ = _orig.__all__
+
+def build_wheel(wheel_directory, config_settings=None, metadata_directory=None):
+    """Build wheel with config_settings support for acceleration and repair options."""
+    
+    if config_settings:
+        # Handle uv -C flag format: -Caccel=cuda, -Crepair=false, etc.
+        for key, value in config_settings.items():
+            if key == 'accel':
+                # Handle acceleration options
+                if isinstance(value, str):
+                    value = [value]
+                elif not isinstance(value, list):
+                    value = [str(value)]
+                
+                for accel in value:
+                    accel = accel.lower()
+                    if 'cuda' in accel:
+                        os.environ['GGML_CUDA'] = '1'
+                        print("Enabling CUDA support via config-settings")
+                    elif 'coreml' in accel:
+                        os.environ['WHISPER_COREML'] = '1'
+                        os.environ['WHISPER_COREML_ALLOW_FALLBACK'] = '1'
+                        print("Enabling CoreML support via config-settings")
+                    elif 'vulkan' in accel:
+                        os.environ['GGML_VULKAN'] = '1'
+                        print("Enabling Vulkan support via config-settings")
+                    elif 'openblas' in accel or 'blas' in accel:
+                        os.environ['GGML_BLAS'] = '1'
+                        print("Enabling OpenBLAS support via config-settings")
+            
+            elif key == 'repair':
+                # Handle repair option
+                if str(value).lower() in ['false', '0', 'no', 'off']:
+                    os.environ['NO_REPAIR'] = '1'
+                    print("Disabling wheel repair via config-settings")
+                elif str(value).lower() in ['true', '1', 'yes', 'on']:
+                    os.environ.pop('NO_REPAIR', None)
+                    print("Enabling wheel repair via config-settings")
+        
+        # Remove our custom options before passing to setuptools
+        # setuptools doesn't understand them and will error
+        cleaned_settings = {k: v for k, v in config_settings.items() 
+                          if k not in ['accel', 'repair']}
+        config_settings = cleaned_settings if cleaned_settings else None
+    
+    return _orig.build_wheel(wheel_directory, config_settings, metadata_directory)
+
+# Re-export other functions
+build_sdist = _orig.build_sdist
+prepare_metadata_for_build_wheel = _orig.prepare_metadata_for_build_wheel
+get_requires_for_build_wheel = _orig.get_requires_for_build_wheel
+get_requires_for_build_sdist = _orig.get_requires_for_build_sdist

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,8 @@ requires = [
     "repairwheel",
     "setuptools-scm>=8"
 ]
-build-backend = "setuptools.build_meta"
+build-backend = "backend"
+backend-path = ["."]
 
 [tool.mypy]
 files = "setup.py"


### PR DESCRIPTION
Implement a PEP 517 build backend to handle acceleration and wheel repair options via `--config-settings` instead of relying on env variables. This works much better with caching front-ends such as uv.

Usage: `pip install . --config-settings="accel=cuda"` or `uv add . -Caccel=cuda`

 - [x] Small changes to repair Cmake cache file corruption.
 - [x] Update README with unified hardware acceleration documentation