### PR TITLE
fix: adjust language detection loop to include max language ID

### DIFF
--- a/pywhispercpp/model.py
+++ b/pywhispercpp/model.py
@@ -244,7 +244,7 @@ class Model:
         """
         n = pw.whisper_lang_max_id()
         res = []
-        for i in range(n):
+        for i in range(n+1):
             res.append(pw.whisper_lang_str(i))
         return res
 


### PR DESCRIPTION
Currently, the last language 'yue' is not showing in available_languages.