### PR TITLE
chore: update whisper.cpp submodule to v1.8.2, build for all cpu variants

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -53,10 +53,11 @@ jobs:
     - name: Build wheels
       run: python -m cibuildwheel --output-dir wheelhouse
       env:
-        CIBW_ARCHS: auto
+        # Whisper.cpp tries to use BMI2 on 32 bit Windows, so don't target 32 bit Windows to avoid that bug. See https://github.com/ggml-org/whisper.cpp/pull/3543
+        CIBW_ARCHS: ${{ contains(matrix.os, 'windows') && 'auto64' || 'auto' }}
          # for windows setup.py repairwheel step should solve it
         CIBW_SKIP: pp* cp38-*
-        CIBW_ENVIRONMENT: ${{ contains(matrix.os, 'arm') && 'CMAKE_ARGS="-DGGML_NATIVE=OFF -DGGML_CPU_ARM_ARCH=armv8-a"' || '' }}
+        CIBW_ENVIRONMENT: CMAKE_ARGS="-DGGML_BACKEND_DL=ON -DGGML_CPU_ALL_VARIANTS=ON"
 
     - name: Verify clean directory
       run: git diff --exit-code


### PR DESCRIPTION
Update whisper.cpp from 1.7.6 to 1.8.2: https://github.com/ggml-org/whisper.cpp/releases

There are a number of useful improvements in these releases, including some significant performance gains.

Disable 32 bit Windows because whisper.cpp doesn't currently build for it, see https://github.com/ggml-org/whisper.cpp/pull/3543

The best variant will be selected at run time resulting in better performance.

This PR is an alternative to https://github.com/absadiki/pywhispercpp/pull/144 - it offers the advantage of building for all cpu variants allowing the best one to be automatically selected at runtime resulting in improved performance. However, targeting 32 bit Windows must be disabled. I don't know if anyone uses or cares about 32 bit Windows, so that probably is not problematic.