### PR TITLE
Add OpenVINO initialization routine

### DIFF
--- a/pywhispercpp/model.py
+++ b/pywhispercpp/model.py
@@ -254,8 +254,10 @@ class Model:
         :return:
         """
         logger.info("Initializing the model ...")
+
         with utils.redirect_stderr(to=self.redirect_whispercpp_logs_to):
             self._ctx = pw.whisper_init_from_file(self.model_path)
+            pw.whisper_ctx_init_openvino_encoder(self._ctx)
 
     def _set_params(self, kwargs: dict) -> None:
         """

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -226,6 +226,11 @@ int whisper_full_wrapper(
     return whisper_full(ctx_w->ptr, params, samples_ptr, n_samples);
 }
 
+int whisper_ctx_init_openvino_encoder_wrapper(struct whisper_context_wrapper * ctx_w) {
+    whisper_ctx_init_openvino_encoder(ctx_w->ptr, nullptr, "CPU", nullptr);
+    return 0;
+}
+
 int whisper_full_parallel_wrapper(
         struct whisper_context_wrapper * ctx_w,
         struct whisper_full_params   params,
@@ -666,6 +671,10 @@ PYBIND11_MODULE(_pywhispercpp, m) {
                                                                                 "This contains probabilities, timestamps, etc.");
 
     m.def("whisper_full_get_token_p", &whisper_full_get_token_p_wrapper, "Get the probability of the specified token in the specified segment.");
+
+    ////////////////////////////////////////////////////////////////////////////
+
+    m.def("whisper_ctx_init_openvino_encoder", &whisper_ctx_init_openvino_encoder_wrapper, "Initialize OpenVINO encoder.");
 
     ////////////////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
While the README clearly states how to enable OpenVINO the code is missing the call to load the OpenVINO encoder. This change adds the msising call.

Note that the compute device is currently hard-coded. I suspect that OpenVINO is mainly used for ARM architecture where it doesn't matter. If need arises the compute device parameter can be added at a later point in time.