### PR TITLE
Fix 162

### DIFF
--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -19,8 +19,9 @@ jobs:
             cmake_args: -DGGML_BMI2=OFF
             archflags: ""
           - platform: macos-14
-            cmake_args: -DGGML_NATIVE=OFF -DGGML_CPU_ARM_ARCH=armv8-a -DCMAKE_OSX_ARCHITECTURES=arm64;x86_64
-            archflags: -arch arm64 -arch x86_64
+            # cmake_args: -DGGML_NATIVE=OFF -DGGML_CPU_ARM_ARCH=armv8-a -DCMAKE_OSX_ARCHITECTURES=arm64;x86_64
+            cmake_args: -DGGML_NATIVE=OFF -DGGML_CPU_ARM_ARCH=armv8-a
+            # archflags: -arch arm64 -arch x86_64
           - platform: ubuntu-latest
             cmake_args: ""
             archflags: ""

--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -33,6 +33,10 @@ jobs:
       run: python -m pip install -r requirements.txt
 
     - name: Build and install
+      env:
+        CMAKE_ARGS: >-
+          ${{ contains(matrix.platform, 'macos-14') && '-DGGML_NATIVE=OFF -DGGML_CPU_ARM_ARCH=armv8-a' || '' }}
+          ${{ contains(matrix.platform, 'windows') && '-DGGML_BMI2=OFF' || '' }}
       run: pip install --verbose .[test]
 
 #    - name: Test C-API

--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -19,8 +19,11 @@ jobs:
             cmake_args: -DGGML_BMI2=OFF
             archflags: ""
           - platform: macos-14
-            # cmake_args: -DGGML_NATIVE=OFF -DGGML_CPU_ARM_ARCH=armv8-a -DCMAKE_OSX_ARCHITECTURES=arm64;x86_64
-            cmake_args: -DGGML_NATIVE=OFF -DGGML_CPU_ARM_ARCH=armv8-a
+
+            cmake_args: >-
+              -DGGML_NATIVE=OFF 
+              -DGGML_CPU_ARM_ARCH=armv8-a
+            # -DCMAKE_OSX_ARCHITECTURES=arm64;x86_64
             # archflags: -arch arm64 -arch x86_64
           - platform: ubuntu-latest
             cmake_args: ""

--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -17,17 +17,10 @@ jobs:
         include:
           - platform: windows-latest
             cmake_args: -DGGML_BMI2=OFF
-            archflags: ""
           - platform: macos-14
             cmake_args: >-
               -DGGML_NATIVE=OFF 
               -DGGML_CPU_ARM_ARCH=armv8-a
-            # these were left for refrence 
-            # -DCMAKE_OSX_ARCHITECTURES=arm64;x86_64
-            # archflags: -arch arm64 -arch x86_64
-          - platform: ubuntu-latest
-            cmake_args: ""
-            archflags: ""
 
     runs-on: ${{ matrix.platform }}
 

--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -19,10 +19,10 @@ jobs:
             cmake_args: -DGGML_BMI2=OFF
             archflags: ""
           - platform: macos-14
-
             cmake_args: >-
               -DGGML_NATIVE=OFF 
               -DGGML_CPU_ARM_ARCH=armv8-a
+            # these were left for refrence 
             # -DCMAKE_OSX_ARCHITECTURES=arm64;x86_64
             # archflags: -arch arm64 -arch x86_64
           - platform: ubuntu-latest
@@ -32,11 +32,11 @@ jobs:
     runs-on: ${{ matrix.platform }}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         submodules: true
 
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -14,6 +14,16 @@ jobs:
       matrix:
         platform: [windows-latest, macos-14, ubuntu-latest]
         python-version: ["3.8", "3.11"]
+        include:
+          - platform: windows-latest
+            cmake_args: -DGGML_BMI2=OFF
+            archflags: ""
+          - platform: macos-14
+            cmake_args: -DGGML_NATIVE=OFF -DGGML_CPU_ARM_ARCH=armv8-a -DCMAKE_OSX_ARCHITECTURES=arm64;x86_64
+            archflags: -arch arm64 -arch x86_64
+          - platform: ubuntu-latest
+            cmake_args: ""
+            archflags: ""
 
     runs-on: ${{ matrix.platform }}
 
@@ -34,9 +44,8 @@ jobs:
 
     - name: Build and install
       env:
-        CMAKE_ARGS: >-
-          ${{ contains(matrix.platform, 'macos-14') && '-DGGML_NATIVE=OFF -DGGML_CPU_ARM_ARCH=armv8-a' || '' }}
-          ${{ contains(matrix.platform, 'windows') && '-DGGML_BMI2=OFF' || '' }}
+        CMAKE_ARGS: ${{ matrix.cmake_args }}
+        ARCHFLAGS: ${{ matrix.archflags }}
       run: pip install --verbose .[test]
 
 #    - name: Test C-API

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -15,7 +15,7 @@ jobs:
     name: Build SDist
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         submodules: true
 
@@ -25,7 +25,7 @@ jobs:
     - name: Check metadata
       run: pipx run twine check dist/*
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v7
       with:
         name: artifact-sdist
         path: dist/*.tar.gz
@@ -40,12 +40,12 @@ jobs:
         os: [ubuntu-24.04-arm, ubuntu-latest, windows-2022, macos-14]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         submodules: true
 
     # Used to host cibuildwheel
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@v6
 
     - name: Install cibuildwheel
       run: python -m pip install cibuildwheel
@@ -67,7 +67,7 @@ jobs:
       run: ls wheelhouse
 
     - name: Upload wheels
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: artifact-${{ matrix.os }}
         path: wheelhouse/*.whl
@@ -83,11 +83,11 @@ jobs:
         python-version: [3.11, 3.12, 3.13]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         submodules: true
 
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@v8
       with:
         pattern: artifact-*
         merge-multiple: true
@@ -98,7 +98,7 @@ jobs:
         ls -l wheelhouse
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -123,11 +123,11 @@ jobs:
     if: github.event_name == 'release' && github.event.action == 'published'
 
     steps:
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@v6
       with:
         python-version: "3.x"
 
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@v8
       with:
         pattern: artifact-*
         merge-multiple: true

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -37,7 +37,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04-arm, ubuntu-latest, windows-2022, macos-14]
+        include:
+          - os: ubuntu-24.04-arm
+            cmake_args: "-DGGML_NATIVE=OFF -DGGML_CPU_ARM_ARCH=armv8-a"
+          - os: ubuntu-latest
+            cmake_args: "-DGGML_NATIVE=OFF"
+          - os: windows-2022
+            # Whisper.cpp tries to use BMI2 on 32 bit Windows, so disable BMI2 when building on Windows to avoid that bug. See https://github.com/ggml-org/whisper.cpp/pull/3543
+            # If Windows still crashes after this, the next step would be disabling GGML_AVX, GGML_AVX2, GGML_FMA, and GGML_F16C with:
+            # -DGGML_AVX=OFF -DGGML_AVX2=OFF -DGGML_FMA=OFF -DGGML_F16C=OFF
+            # NOTE: these may also help the ubuntu-latest builds as well
+            cmake_args: "-DGGML_NATIVE=OFF -DGGML_BMI2=OFF -DGGML_AVX512=OFF -DGGML_AVX512_VBMI=OFF -DGGML_AVX512_VNNI=OFF -DGGML_AVX512_BF16=OFF"
+          - os: macos-14
+            cmake_args: "-DGGML_NATIVE=OFF"
 
     steps:
     - uses: actions/checkout@v6
@@ -56,8 +68,7 @@ jobs:
         CIBW_ARCHS: auto
          # for windows setup.py repairwheel step should solve it
         CIBW_SKIP: pp* cp38-*
-        # Whisper.cpp tries to use BMI2 on 32 bit Windows, so disable BMI2 when building on Windows to avoid that bug. See https://github.com/ggml-org/whisper.cpp/pull/3543
-        CIBW_ENVIRONMENT: CMAKE_ARGS="${{ contains(matrix.os, 'arm') && '-DGGML_NATIVE=OFF -DGGML_CPU_ARM_ARCH=armv8-a' || ''}} ${{ contains(matrix.os, 'windows') && '-DGGML_BMI2=OFF' || '' }}"
+        CIBW_ENVIRONMENT: CMAKE_ARGS="${{ matrix.cmake_args }}"
 
     - name: Verify clean directory
       run: git diff --exit-code

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ _generate/
 *.egg-info
 *env*
 
+logs_*
 
 # custom
 .idea

--- a/setup.py
+++ b/setup.py
@@ -77,6 +77,17 @@ class CMakeBuild(build_ext):
                     "-DCMAKE_INSTALL_RPATH=@loader_path",
                     "-DCMAKE_BUILD_WITH_INSTALL_RPATH=ON"
                 ]
+                
+                
+                os.environ.setdefault("MACOSX_DEPLOYMENT_TARGET", "14.0")
+                cmake_args += [
+                    f"-DCMAKE_OSX_DEPLOYMENT_TARGET={os.environ['MACOSX_DEPLOYMENT_TARGET']}"
+                ]
+
+                archs = re.findall(r"-arch (\S+)", os.environ.get("ARCHFLAGS", ""))
+                if archs:
+                    cmake_args += [f"-DCMAKE_OSX_ARCHITECTURES={';'.join(archs)}"]
+                
             elif sys.platform.startswith('linux'):
                 # Linux-specific settings
                 cmake_args += [

--- a/setup.py
+++ b/setup.py
@@ -78,16 +78,6 @@ class CMakeBuild(build_ext):
                     "-DCMAKE_BUILD_WITH_INSTALL_RPATH=ON"
                 ]
                 
-                
-                os.environ.setdefault("MACOSX_DEPLOYMENT_TARGET", "14.0")
-                cmake_args += [
-                    f"-DCMAKE_OSX_DEPLOYMENT_TARGET={os.environ['MACOSX_DEPLOYMENT_TARGET']}"
-                ]
-
-                archs = re.findall(r"-arch (\S+)", os.environ.get("ARCHFLAGS", ""))
-                if archs:
-                    cmake_args += [f"-DCMAKE_OSX_ARCHITECTURES={';'.join(archs)}"]
-                
             elif sys.platform.startswith('linux'):
                 # Linux-specific settings
                 cmake_args += [
@@ -143,6 +133,11 @@ class CMakeBuild(build_ext):
                 build_args += ["--config", cfg]
 
         if sys.platform.startswith("darwin"):
+          
+            os.environ.setdefault("MACOSX_DEPLOYMENT_TARGET", "14.0")
+            cmake_args += [
+                f"-DCMAKE_OSX_DEPLOYMENT_TARGET={os.environ['MACOSX_DEPLOYMENT_TARGET']}"
+            ]
             # Cross-compile support for macOS - respect ARCHFLAGS if set
             archs = re.findall(r"-arch (\S+)", os.environ.get("ARCHFLAGS", ""))
             if archs:

--- a/setup.py
+++ b/setup.py
@@ -191,7 +191,8 @@ class RepairWheel(bdist_wheel):
         if os.environ.get('NO_REPAIR', '0') == '1':
             print("Skipping wheel repair")
             return
-        if os.environ.get('CIBUILDWHEEL', '0') == '0' or sys.platform.startswith('win'):
+        # if os.environ.get('CIBUILDWHEEL', '0') == '0' or sys.platform.startswith('win'):
+        if sys.platform.startswith('win'):
             # for linux and macos we use the default wheel repair command from cibuildwheel, for windows we need to do it manually as there is no repair command
             self.repair_wheel()
 


### PR DESCRIPTION

- Add CMAKE_ARGS to pip.yml
- Remove os.environ.get('CIBUILDWHEEL', '0') == '0' so that self.repair_wheel() doesn't run with a regular pip install

Both of those stopped the failure on macos but then it was warning:
Warning: G] This wheel needs a higher macOS version than the version your Python interpreter is compiled against. To silence this warning, set MACOSX_DEPLOYMENT_TARGET to at least 14_0 or recreate these files with lower MACOSX_DEPLOYMENT_TARGET:

so I added default target of macos target 14.0 in setup.py

I test ran pip.yml and wheels.yml and while waiting i went ahead and bumped all of the actions to stop the node.js v20 deprecated warnings. Both were successful. I pushed a retested with the updated actions and both were successful. see below if you are interested.


[last pip run](https://github.com/scottmonster/pywhispercpp/actions/runs/25889826661)


[last wheels run](https://github.com/scottmonster/pywhispercpp/actions/runs/25890031613)


fixes [issue 162](https://github.com/absadiki/pywhispercpp/issues/162)